### PR TITLE
Improve QueueManager, QueueItemInterface, QueueItemTrait

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "prefer-stable": true,
     "extra": {
         "branch-alias": {
-            "dev-master": "0.2.x-dev"
+            "dev-master": "0.3.x-dev"
         }
     },
     "require": {

--- a/src/Charcoal/Queue/AbstractQueueManager.php
+++ b/src/Charcoal/Queue/AbstractQueueManager.php
@@ -505,11 +505,21 @@ abstract class AbstractQueueManager implements
     }
 
     /**
-     * Retrieve the queue item's model.
+     * Retrieve the queue item prototype model.
      *
      * @return QueueItemInterface
      */
-    abstract public function queueItemProto();
+    public function queueItemProto()
+    {
+        return $this->queueItemFactory()->get($this->getQueueItemClass());
+    }
+
+    /**
+     * Retrieve the class name of the queue item model.
+     *
+     * @return string
+     */
+    abstract public function getQueueItemClass();
 
     /**
      * @return FactoryInterface

--- a/src/Charcoal/Queue/AbstractQueueManager.php
+++ b/src/Charcoal/Queue/AbstractQueueManager.php
@@ -353,10 +353,19 @@ abstract class AbstractQueueManager implements
                 continue;
             }
 
-            // Throttle according to processing rate.
-            if ($this->rate > 0) {
-                usleep(1000000 / $this->rate);
-            }
+            $this->throttle();
+        }
+    }
+
+    /**
+     * Throttle processing of items.
+     *
+     * @return void
+     */
+    private function throttle()
+    {
+        if ($this->rate > 0) {
+            usleep(1000000 / $this->rate);
         }
     }
 

--- a/src/Charcoal/Queue/AbstractQueueManager.php
+++ b/src/Charcoal/Queue/AbstractQueueManager.php
@@ -465,7 +465,14 @@ abstract class AbstractQueueManager implements
      */
     public function totalChunks()
     {
-        return (int)ceil($this->totalQueuedItems() / $this->chunkSize());
+        $total = $this->totalQueuedItems();
+
+        $limit = $this->limit();
+        if ($limit > 0 && $total > $limit) {
+            $total = $limit;
+        }
+
+        return (int)ceil($total / $this->chunkSize());
     }
 
     /**

--- a/src/Charcoal/Queue/AbstractQueueManager.php
+++ b/src/Charcoal/Queue/AbstractQueueManager.php
@@ -65,9 +65,9 @@ abstract class AbstractQueueManager implements
     /**
      * The chunk size to batch the queue with.
      *
-     * @var integer|null
+     * @var integer
      */
-    private $chunkSize = null;
+    private $chunkSize = 0;
 
     /**
      * The queue ID.
@@ -311,7 +311,7 @@ abstract class AbstractQueueManager implements
             $callback = $this->processedCallback;
         }
 
-        if (!is_null($this->chunkSize())) {
+        if ($this->chunkSize() > 0) {
             $totalChunks = $this->totalChunks();
             for ($i = 0; $i <= $totalChunks; $i++) {
                 $queuedItems = $this->loadQueueItems();
@@ -395,7 +395,7 @@ abstract class AbstractQueueManager implements
             'mode'     => 'asc',
         ]);
 
-        if (!is_null($this->chunkSize())) {
+        if ($this->chunkSize() > 0) {
             $loader->setNumPerPage($this->chunkSize());
         }
 

--- a/src/Charcoal/Queue/QueueItemInterface.php
+++ b/src/Charcoal/Queue/QueueItemInterface.php
@@ -12,13 +12,14 @@ interface QueueItemInterface extends ModelInterface
     /**
      * Process the item.
      *
-     * @param  callable $callback        An optional callback routine executed after the item is processed.
+     * @param  callable $alwaysCallback  An optional callback routine executed after the item is processed.
      * @param  callable $successCallback An optional callback routine executed when the item is resolved.
      * @param  callable $failureCallback An optional callback routine executed when the item is rejected.
-     * @return boolean  Success / Failure
+     * @return boolean|null Returns TRUE i this item was successfully processed,
+     *     FALSE on failure or if an error occurs, NULL if this item is already processed.
      */
     public function process(
-        callable $callback = null,
+        callable $alwaysCallback = null,
         callable $successCallback = null,
         callable $failureCallback = null
     );

--- a/src/Charcoal/Queue/QueueItemTrait.php
+++ b/src/Charcoal/Queue/QueueItemTrait.php
@@ -53,13 +53,14 @@ trait QueueItemTrait
     /**
      * Process the item.
      *
-     * @param  callable $callback        An optional callback routine executed after the item is processed.
+     * @param  callable $alwaysCallback  An optional callback routine executed after the item is processed.
      * @param  callable $successCallback An optional callback routine executed when the item is resolved.
      * @param  callable $failureCallback An optional callback routine executed when the item is rejected.
-     * @return boolean  Success / Failure
+     * @return boolean|null Returns TRUE i this item was successfully processed,
+     *     FALSE on failure or if an error occurs, NULL if this item is already processed.
      */
     abstract public function process(
-        callable $callback = null,
+        callable $alwaysCallback = null,
         callable $successCallback = null,
         callable $failureCallback = null
     );


### PR DESCRIPTION
Breaking:

- `QueueManager`: Replace abstract method `queueItemProto()` with `queueItemClass()`. The former method is now concrete and uses the new abstract method (if this PR is approved, I can create pull requests for charcoal-email and charcoal-messaging).
- `QueueItem*`: Rename first argument in `process()` to clarify usage.

Changed:

- `QueueManager`
  - Decoupled throttling from `processItems()` method to allow customization in child classes.
  - Decoupled `CollectionLoader` from `loadQueueItems()` and `totalQueuedItems()` to unify query conditions.
  - Added log summary of processed queue(s) to keep a record (instead of just displaying results in CLI).
  - Fixed edge case when `chunkSize` is zero by replacing null checks with greater-than-zero checks.
  - Fixed support for mixing `chunkSize` and `limit`. If both are defined, the total chunks is determined by whether there are more queued items than the limit.
