### PR TITLE
feat/queue-expiry

### DIFF
--- a/src/Charcoal/Queue/AbstractQueueManager.php
+++ b/src/Charcoal/Queue/AbstractQueueManager.php
@@ -436,6 +436,9 @@ abstract class AbstractQueueManager implements
             'operator' => '<',
             'value'    => date('Y-m-d H:i:s'),
         ]);
+        $loader->addFilter([
+            'condition' => '(expiry_date > NOW() OR expiry_date IS NULL)',
+        ]);
 
         $queueId = $this->queueId();
         if ($queueId) {

--- a/src/Charcoal/Queue/QueueItemInterface.php
+++ b/src/Charcoal/Queue/QueueItemInterface.php
@@ -93,4 +93,11 @@ interface QueueItemInterface extends ModelInterface
      * @return null|\DateTimeInterface
      */
     public function processedDate();
+
+    /**
+     * Retrieve the date/time the item should be expired at.
+     *
+     * @return null|\DateTimeInterface
+     */
+    public function expiryDate();
 }

--- a/src/Charcoal/Queue/QueueItemTrait.php
+++ b/src/Charcoal/Queue/QueueItemTrait.php
@@ -66,7 +66,7 @@ trait QueueItemTrait
      *
      * @var integer $defaultExpiryInSeconde
      */
-    private $defaultExpiryInSeconds = 84400;
+    private $defaultExpiryInSeconds = 86400;
 
     /**
      * Process the item.

--- a/src/Charcoal/Queue/QueueItemTrait.php
+++ b/src/Charcoal/Queue/QueueItemTrait.php
@@ -360,7 +360,7 @@ trait QueueItemTrait
      */
     protected function generateExpiry()
     {
-        $date = (clone $this['processingDate']) ?? new DateTime();
+        $date = (clone $this['processingDate'] ?? new DateTime());
         $date->add(new DateInterval('PT'.$this->defaultExpiryInSeconds.'S'));
 
         return $this->setExpiryDate($date);


### PR DESCRIPTION
Provide a expiry foncitonality to queue items

Expiry will be autogenerated for 24 hours after the processing date

Breaking changes : All queue item objects must implement the new property expiry_date

All changes : 

b1e0641 feat(queue-item): add queue item expiry generation and props
f18145a feat(queue-manager): add a filter to exclude expired queue items