### PR TITLE
fix/queue-processing

### DIFF
--- a/src/Charcoal/Queue/AbstractQueueManager.php
+++ b/src/Charcoal/Queue/AbstractQueueManager.php
@@ -313,7 +313,7 @@ abstract class AbstractQueueManager implements
 
         if ($this->chunkSize() > 0) {
             $totalChunks = $this->totalChunks();
-            for ($i = 0; $i <= $totalChunks; $i++) {
+            for ($i = 0; $i < $totalChunks; $i++) {
                 $queuedItems = $this->loadQueueItems();
                 $this->processItems($queuedItems);
             }

--- a/src/Charcoal/Queue/QueueItemInterface.php
+++ b/src/Charcoal/Queue/QueueItemInterface.php
@@ -9,9 +9,9 @@ use Charcoal\Model\ModelInterface;
  */
 interface QueueItemInterface extends ModelInterface
 {
-    const SUCCESS_STATUS = 'success';
-    const FAILED_STATUS = 'failed';
-    const RETRY_STATUS = 'retry';
+    const STATUS_SUCCESS = 'STATUS_SUCCESS';
+    const STATUS_FAILED = 'STATUS_FAILED';
+    const STATUS_RETRY = 'STATUS_RETRY';
 
     /**
      * Process the item.

--- a/src/Charcoal/Queue/QueueItemInterface.php
+++ b/src/Charcoal/Queue/QueueItemInterface.php
@@ -9,6 +9,10 @@ use Charcoal\Model\ModelInterface;
  */
 interface QueueItemInterface extends ModelInterface
 {
+    const SUCCESS_STATUS = 'success';
+    const FAILED_STATUS = 'failed';
+    const RETRY_STATUS = 'retry';
+
     /**
      * Process the item.
      *
@@ -95,9 +99,35 @@ interface QueueItemInterface extends ModelInterface
     public function processedDate();
 
     /**
+     * Set the item's processed status.
+     *
+     * @param boolean $processed Whether the item has been processed.
+     * @return self
+     */
+    public function setProcessed($processed);
+
+    /**
+     * Determine if the item has been processed.
+     *
+     * @return boolean
+     */
+    public function processed();
+
+    /**
      * Retrieve the date/time the item should be expired at.
      *
      * @return null|\DateTimeInterface
      */
     public function expiryDate();
+
+    /**
+     * @param string $status Status for QueueItemTrait.
+     * @return self
+     */
+    public function setStatus($status);
+
+    /**
+     * @return null|string
+     */
+    public function status();
 }

--- a/src/Charcoal/Queue/QueueItemTrait.php
+++ b/src/Charcoal/Queue/QueueItemTrait.php
@@ -69,6 +69,13 @@ trait QueueItemTrait
     private $defaultExpiryInSeconds = 86400;
 
     /**
+     * The status of the queue item.
+     *
+     * @var string
+     */
+    private $status;
+
+    /**
      * Process the item.
      *
      * @param  callable $alwaysCallback  An optional callback routine executed after the item is processed.
@@ -82,6 +89,22 @@ trait QueueItemTrait
         callable $successCallback = null,
         callable $failureCallback = null
     );
+
+    /**
+     * @param Exception $e Exception to log.
+     * @return void
+     */
+    protected function logProcessingException(Exception $e)
+    {
+        $this->logger->error(
+            sprintf('Could not process a queue item: %s', $e->getMessage()),
+            [
+                'manager' => get_called_class(),
+                'queueId' => $this->queueId(),
+                'itemId'  => $this->id(),
+            ]
+        );
+    }
 
     /**
      * Set the queue item's data.
@@ -330,6 +353,25 @@ trait QueueItemTrait
         }
 
         $this->expiryDate = $ts;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function status()
+    {
+        return $this->status;
+    }
+
+    /**
+     * @param string $status Status for QueueItemTrait.
+     * @return self
+     */
+    public function setStatus($status)
+    {
+        $this->status = $status;
 
         return $this;
     }


### PR DESCRIPTION
This PR aims to eliminate any chances a queue item can be processed more than once.
It transfers all responsibility over the `processed` state of a queue item to the AbstractQueueManager